### PR TITLE
Add SageMaker deployment cookbook for Foundation-Sec-8B-Reasoning

### DIFF
--- a/3_adoptions/deployment/sagemaker/README.md
+++ b/3_adoptions/deployment/sagemaker/README.md
@@ -1,6 +1,6 @@
 # Deployment and Inference with Amazon SageMaker AI
 
-This directory contains cookbooks for deploying and running inference with Foundation AI models on Amazon SageMaker. We provide examples for both our base model and instruct-tuned model.
+This directory contains cookbooks for deploying and running inference with Foundation AI models on Amazon SageMaker. We provide examples for our base model, instruct-tuned model, and reasoning model.
 
 ## Available Models
 

--- a/3_adoptions/deployment/sagemaker/README.md
+++ b/3_adoptions/deployment/sagemaker/README.md
@@ -16,6 +16,12 @@ Our instruction-fine-tuned model optimized for chat and instruction-following ta
 - **Inference**: [foundation_sec_8b_instruct/inference.ipynb](./foundation_sec_8b_instruct/inference.ipynb)
 - **Documentation**: [foundation_sec_8b_instruct/README.md](./foundation_sec_8b_instruct/README.md)
 
+### Foundation-Sec-8B-Reasoning (Reasoning Model)
+Our reasoning model that produces chain-of-thought traces for security tasks. Uses the vLLM container with the `minimax_m2` reasoning parser.
+- **Deploy**: [foundation_sec_8b_reasoning/deploy.ipynb](./foundation_sec_8b_reasoning/deploy.ipynb)
+- **Inference**: [foundation_sec_8b_reasoning/inference.ipynb](./foundation_sec_8b_reasoning/inference.ipynb)
+- **Documentation**: [foundation_sec_8b_reasoning/README.md](./foundation_sec_8b_reasoning/README.md)
+
 ### Foundation-Sec-8B-Instruct-Q8_0-GGUF (8 bit quantized IFT Model)
 
 - **Deploy**: [foundation_sec_8b_instruct_quantized/deploy.ipynb](./foundation_sec_8b_instruct_quantized/cpu/deploy.ipynb)
@@ -27,6 +33,7 @@ Our instruction-fine-tuned model optimized for chat and instruction-following ta
 1. Choose the model that best fits your use case:
    - **Base Model**: Better for completion tasks, fine-tuning, or when you need maximum flexibility
    - **Instruct Model**: Better for chat applications, Q&A, and instruction-following tasks
+   - **Reasoning Model**: Better for complex security analysis tasks that benefit from chain-of-thought reasoning
 
 2. Navigate to the appropriate model directory
 3. Start with the `deploy.ipynb` notebook to set up your SageMaker endpoint

--- a/3_adoptions/deployment/sagemaker/foundation_sec_8b_reasoning/README.md
+++ b/3_adoptions/deployment/sagemaker/foundation_sec_8b_reasoning/README.md
@@ -1,0 +1,24 @@
+# Foundation-Sec-8B-Reasoning Model - SageMaker Deployment
+
+This directory contains cookbooks for deploying and running inference with the **Foundation-Sec-8B-Reasoning** model on Amazon SageMaker.
+
+This is a reasoning model that produces chain-of-thought tokens, so it requires:
+- A vLLM container image with the `minimax_m2` reasoning parser
+- A `g6e` family instance (or better) to handle the higher token throughput from reasoning traces
+
+We provide two sample notebooks:
+1. Deploy Model: Deploy the Foundation-Sec-8B-Reasoning model on SageMaker and create an inference endpoint ([link](./deploy.ipynb)).
+2. Run Inference: Perform inference using the created endpoint ([link](./inference.ipynb)).
+
+Please note that we assume you already have AWS accounts or contracts and are aware that deployments will incur costs.
+
+## Important Notes
+
+- **Env var prefix:** This vLLM container requires `SM_VLLM_*` prefixed env vars. Do not use DJL-style vars (`HF_MODEL_ID`, `OPTION_REASONING_PARSER`, etc.) — they will be silently ignored.
+- **Instance type:** Use `g6e` family (e.g., `ml.g6e.2xlarge`) or better. Lower-tier instances like `g6.xlarge` are not recommended for this reasoning model.
+
+## Troubleshooting
+
+If you see raw `<think>`/`</think>` tokens in the response instead of a separate `reasoning_content` field, the reasoning parser is not configured. Check CloudWatch logs for the `non-default args` line. It should include `'reasoning_parser': 'minimax_m2'`. If it only shows `{'port': 8080}`, the env vars are not being read.
+
+For additional questions, please refer to the main [SageMaker README](../README.md) or consult the AWS SageMaker documentation.

--- a/3_adoptions/deployment/sagemaker/foundation_sec_8b_reasoning/deploy.ipynb
+++ b/3_adoptions/deployment/sagemaker/foundation_sec_8b_reasoning/deploy.ipynb
@@ -1,0 +1,115 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro-md",
+   "metadata": {},
+   "source": [
+    "# Deployment\n",
+    "\n",
+    "Let's deploy the Foundation AI Foundation-Sec-8B-Reasoning model onto Amazon SageMaker AI. <br>\n",
+    "You can use the model deployed by this notebook for inference. Refer to [the inference notebook](https://github.com/RobustIntelligence/foundation-ai-cookbook/blob/main/3_adoptions/deployment/sagemaker/foundation_sec_8b_reasoning/inference.ipynb) for sample code.\n",
+    "\n",
+    "This is a reasoning model that produces chain-of-thought tokens during inference. It requires:\n",
+    "- The **vLLM** container image (with the `minimax_m2` reasoning parser)\n",
+    "- A **g6e** family instance or better (e.g., `ml.g6e.2xlarge`) to handle the higher token throughput\n",
+    "\n",
+    "As a prerequisite, please launch JupyterLab on SageMaker in your AWS environment. For more details, visit: \n",
+    "https://docs.aws.amazon.com/sagemaker/latest/dg/studio-updated-jl.html"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "imports",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sagemaker\n",
+    "import boto3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "config",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MODEL_NAME = 'fdtn-ai/Foundation-Sec-8B-Reasoning'\n",
+    "INSTANCE_TYPE = 'ml.g6e.2xlarge'\n",
+    "TIMEOUT = 900"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "role",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    role = sagemaker.get_execution_role()\n",
+    "except ValueError:\n",
+    "    iam = boto3.client('iam')\n",
+    "    role = iam.get_role(RoleName='sagemaker_execution_role')['Role']['Arn']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "container-md",
+   "metadata": {},
+   "source": "We use the AWS-released vLLM container image. The reasoning model requires the `minimax_m2` reasoning parser,\nwhich we configure via the `SM_VLLM_REASONING_PARSER` environment variable."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "container",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "container_uri = \"763104351884.dkr.ecr.us-east-1.amazonaws.com/vllm:0.17.0-gpu-py312-cu129-ubuntu22.04-sagemaker\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "endpoint-name",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "endpoint_name = sagemaker.utils.name_from_base(\"Foundation-Sec-8B-Reasoning\")\n",
+    "print(\"Deploying to endpoint:\", endpoint_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "deploy",
+   "metadata": {},
+   "outputs": [],
+   "source": "env_vars = {\n    \"SM_VLLM_MODEL\": MODEL_NAME,\n    \"SM_VLLM_REASONING_PARSER\": \"minimax_m2\",\n    \"SM_VLLM_MAX_MODEL_LEN\": \"32768\",\n    \"SM_VLLM_TRUST_REMOTE_CODE\": \"true\",\n}\n\nmodel = sagemaker.Model(\n    name=endpoint_name,\n    image_uri=container_uri,\n    role=role,\n    env=env_vars,\n)\n\nmodel.deploy(\n    instance_type=INSTANCE_TYPE,\n    initial_instance_count=1,\n    endpoint_name=endpoint_name,\n)"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "outro-md",
+   "metadata": {},
+   "source": [
+    "The predictor's endpoint will be used for [inference](https://github.com/RobustIntelligence/foundation-ai-cookbook/blob/main/3_adoptions/deployment/sagemaker/foundation_sec_8b_reasoning/inference.ipynb). You can also get the endpoint from SageMaker Studio's console."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/3_adoptions/deployment/sagemaker/foundation_sec_8b_reasoning/deploy.ipynb
+++ b/3_adoptions/deployment/sagemaker/foundation_sec_8b_reasoning/deploy.ipynb
@@ -25,6 +25,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%pip install 'sagemaker>=2,<3' --quiet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "pmhsyn48n1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
     "import sagemaker\n",
     "import boto3"
    ]
@@ -35,7 +46,10 @@
    "id": "config",
    "metadata": {},
    "outputs": [],
-   "source": "MODEL_NAME = 'fdtn-ai/Foundation-Sec-8B-Reasoning'\nINSTANCE_TYPE = 'ml.g6e.2xlarge'"
+   "source": [
+    "MODEL_NAME = 'fdtn-ai/Foundation-Sec-8B-Reasoning'\n",
+    "INSTANCE_TYPE = 'ml.g6e.2xlarge'"
+   ]
   },
   {
    "cell_type": "code",
@@ -43,19 +57,16 @@
    "id": "role",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "try:\n",
-    "    role = sagemaker.get_execution_role()\n",
-    "except ValueError:\n",
-    "    iam = boto3.client('iam')\n",
-    "    role = iam.get_role(RoleName='sagemaker_execution_role')['Role']['Arn']"
-   ]
+   "source": "# If running on SageMaker, the execution role is detected automatically.\n# If running locally, paste your SageMaker execution role ARN below.\nIAM_ROLE = ''  # e.g. 'arn:aws:iam::123456789012:role/service-role/AmazonSageMaker-ExecutionRole-...'\n\nif IAM_ROLE:\n    role = IAM_ROLE\nelse:\n    role = sagemaker.get_execution_role()"
   },
   {
    "cell_type": "markdown",
    "id": "container-md",
    "metadata": {},
-   "source": "We use the AWS-released vLLM container image. The reasoning model requires the `minimax_m2` reasoning parser,\nwhich we configure via the `SM_VLLM_REASONING_PARSER` environment variable."
+   "source": [
+    "We use the AWS-released vLLM container image. The reasoning model requires the `minimax_m2` reasoning parser,\n",
+    "which we configure via the `SM_VLLM_REASONING_PARSER` environment variable."
+   ]
   },
   {
    "cell_type": "code",
@@ -63,7 +74,10 @@
    "id": "container",
    "metadata": {},
    "outputs": [],
-   "source": "# Replace us-west-2 with your AWS region in the ECR URI below\ncontainer_uri = \"763104351884.dkr.ecr.us-west-2.amazonaws.com/vllm:0.17.0-gpu-py312-cu129-ubuntu22.04-sagemaker\""
+   "source": [
+    "# Replace us-west-2 with your AWS region in the ECR URI below\n",
+    "container_uri = \"763104351884.dkr.ecr.us-west-2.amazonaws.com/vllm:0.17.0-gpu-py312-cu129-ubuntu22.04-sagemaker\""
+   ]
   },
   {
    "cell_type": "code",
@@ -72,7 +86,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "endpoint_name = sagemaker.utils.name_from_base(\"Foundation-Sec-8B-Reasoning\")\n",
+    "endpoint_name = f\"Foundation-Sec-8B-Reasoning-{int(time.time())}\"\n",
     "print(\"Deploying to endpoint:\", endpoint_name)"
    ]
   },
@@ -82,21 +96,43 @@
    "id": "deploy",
    "metadata": {},
    "outputs": [],
-   "source": "env_vars = {\n    \"SM_VLLM_MODEL\": MODEL_NAME,\n    \"SM_VLLM_REASONING_PARSER\": \"minimax_m2\",\n    \"SM_VLLM_MAX_MODEL_LEN\": \"32768\",\n    \"SM_VLLM_TRUST_REMOTE_CODE\": \"true\",\n}\n\nmodel = sagemaker.Model(\n    name=endpoint_name,\n    image_uri=container_uri,\n    role=role,\n    env=env_vars,\n)\n\nmodel.deploy(\n    instance_type=INSTANCE_TYPE,\n    initial_instance_count=1,\n    endpoint_name=endpoint_name,\n)"
+   "source": [
+    "env_vars = {\n",
+    "    \"SM_VLLM_MODEL\": MODEL_NAME,\n",
+    "    \"SM_VLLM_REASONING_PARSER\": \"minimax_m2\",\n",
+    "    \"SM_VLLM_MAX_MODEL_LEN\": \"32768\",\n",
+    "    \"SM_VLLM_TRUST_REMOTE_CODE\": \"true\",\n",
+    "}\n",
+    "\n",
+    "model = sagemaker.Model(\n",
+    "    name=endpoint_name,\n",
+    "    image_uri=container_uri,\n",
+    "    role=role,\n",
+    "    env=env_vars,\n",
+    ")\n",
+    "\n",
+    "model.deploy(\n",
+    "    instance_type=INSTANCE_TYPE,\n",
+    "    initial_instance_count=1,\n",
+    "    endpoint_name=endpoint_name,\n",
+    ")"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "outro-md",
    "metadata": {},
-   "source": "The predictor's endpoint will be used for [inference](https://github.com/RobustIntelligence/foundation-ai-cookbook/blob/main/3_adoptions/deployment/sagemaker/foundation_sec_8b_reasoning/inference.ipynb). You can also get the endpoint from SageMaker Studio's console."
+   "source": [
+    "The predictor's endpoint will be used for [inference](https://github.com/RobustIntelligence/foundation-ai-cookbook/blob/main/3_adoptions/deployment/sagemaker/foundation_sec_8b_reasoning/inference.ipynb). You can also get the endpoint from SageMaker Studio's console."
+   ]
   },
   {
    "cell_type": "code",
-   "id": "ed99vurp7jw",
-   "source": "# Uncomment to delete the endpoint and avoid ongoing costs\n# sagemaker.Session().delete_endpoint(endpoint_name)",
-   "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "id": "ed99vurp7jw",
+   "metadata": {},
+   "outputs": [],
+   "source": "# Uncomment to delete the endpoint and avoid ongoing costs\n# sagemaker.Session().delete_endpoint(endpoint_name)"
   }
  ],
  "metadata": {
@@ -106,8 +142,16 @@
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.12.0"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,

--- a/3_adoptions/deployment/sagemaker/foundation_sec_8b_reasoning/deploy.ipynb
+++ b/3_adoptions/deployment/sagemaker/foundation_sec_8b_reasoning/deploy.ipynb
@@ -35,11 +35,7 @@
    "id": "config",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "MODEL_NAME = 'fdtn-ai/Foundation-Sec-8B-Reasoning'\n",
-    "INSTANCE_TYPE = 'ml.g6e.2xlarge'\n",
-    "TIMEOUT = 900"
-   ]
+   "source": "MODEL_NAME = 'fdtn-ai/Foundation-Sec-8B-Reasoning'\nINSTANCE_TYPE = 'ml.g6e.2xlarge'"
   },
   {
    "cell_type": "code",
@@ -67,9 +63,7 @@
    "id": "container",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "container_uri = \"763104351884.dkr.ecr.us-east-1.amazonaws.com/vllm:0.17.0-gpu-py312-cu129-ubuntu22.04-sagemaker\""
-   ]
+   "source": "# Replace us-west-2 with your AWS region in the ECR URI below\ncontainer_uri = \"763104351884.dkr.ecr.us-west-2.amazonaws.com/vllm:0.17.0-gpu-py312-cu129-ubuntu22.04-sagemaker\""
   },
   {
    "cell_type": "code",
@@ -94,9 +88,15 @@
    "cell_type": "markdown",
    "id": "outro-md",
    "metadata": {},
-   "source": [
-    "The predictor's endpoint will be used for [inference](https://github.com/RobustIntelligence/foundation-ai-cookbook/blob/main/3_adoptions/deployment/sagemaker/foundation_sec_8b_reasoning/inference.ipynb). You can also get the endpoint from SageMaker Studio's console."
-   ]
+   "source": "The predictor's endpoint will be used for [inference](https://github.com/RobustIntelligence/foundation-ai-cookbook/blob/main/3_adoptions/deployment/sagemaker/foundation_sec_8b_reasoning/inference.ipynb). You can also get the endpoint from SageMaker Studio's console."
+  },
+  {
+   "cell_type": "code",
+   "id": "ed99vurp7jw",
+   "source": "# Uncomment to delete the endpoint and avoid ongoing costs\n# sagemaker.Session().delete_endpoint(endpoint_name)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   }
  ],
  "metadata": {

--- a/3_adoptions/deployment/sagemaker/foundation_sec_8b_reasoning/inference.ipynb
+++ b/3_adoptions/deployment/sagemaker/foundation_sec_8b_reasoning/inference.ipynb
@@ -32,13 +32,7 @@
    "id": "config",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "sagemaker_runtime = boto3.client('sagemaker-runtime')\n",
-    "endpoint_name = ''  # copy & paste an endpoint created by the deployment notebook\n",
-    "\n",
-    "# Reasoning models produce more tokens due to chain-of-thought, so set a higher limit\n",
-    "max_tokens = 8192"
-   ]
+   "source": "sagemaker_runtime = boto3.client('sagemaker-runtime')\nendpoint_name = ''  # copy & paste an endpoint created by the deployment notebook\nassert endpoint_name, \"Set endpoint_name above before running inference\"\n\n# Reasoning models produce more tokens due to chain-of-thought, so set a higher limit\nmax_tokens = 8192"
   },
   {
    "cell_type": "code",
@@ -46,32 +40,7 @@
    "id": "chat-fn",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "def chat_generation(user_prompt):\n",
-    "    messages = [\n",
-    "        {\n",
-    "            \"role\": \"user\",\n",
-    "            \"content\": user_prompt\n",
-    "        }\n",
-    "    ]\n",
-    "    payload = {\n",
-    "        \"messages\": messages,\n",
-    "        \"temperature\": 0.3,\n",
-    "        \"max_tokens\": max_tokens,\n",
-    "    }\n",
-    "    response = sagemaker_runtime.invoke_endpoint(\n",
-    "        EndpointName=endpoint_name,\n",
-    "        Body=json.dumps(payload),\n",
-    "        ContentType=\"application/json\",\n",
-    "        CustomAttributes='accept_eula=false'\n",
-    "    )\n",
-    "    body = json.loads(response['Body'].read().decode('utf-8'))\n",
-    "    message = body[\"choices\"][0][\"message\"]\n",
-    "\n",
-    "    reasoning = message.get(\"reasoning_content\", \"\")\n",
-    "    answer = message.get(\"content\", \"\")\n",
-    "    return reasoning, answer"
-   ]
+   "source": "def chat_generation(user_prompt):\n    messages = [\n        {\n            \"role\": \"user\",\n            \"content\": user_prompt\n        }\n    ]\n    payload = {\n        \"messages\": messages,\n        \"temperature\": 0.3,\n        \"max_tokens\": max_tokens,\n    }\n    response = sagemaker_runtime.invoke_endpoint(\n        EndpointName=endpoint_name,\n        Body=json.dumps(payload),\n        ContentType=\"application/json\",\n    )\n    body = json.loads(response['Body'].read().decode('utf-8'))\n    message = body[\"choices\"][0][\"message\"]\n\n    reasoning = message.get(\"reasoning_content\", \"\")\n    answer = message.get(\"content\", \"\")\n    return reasoning, answer"
   },
   {
    "cell_type": "code",

--- a/3_adoptions/deployment/sagemaker/foundation_sec_8b_reasoning/inference.ipynb
+++ b/3_adoptions/deployment/sagemaker/foundation_sec_8b_reasoning/inference.ipynb
@@ -40,7 +40,7 @@
    "id": "chat-fn",
    "metadata": {},
    "outputs": [],
-   "source": "def chat_generation(user_prompt):\n    messages = [\n        {\n            \"role\": \"user\",\n            \"content\": user_prompt\n        }\n    ]\n    payload = {\n        \"messages\": messages,\n        \"temperature\": 0.3,\n        \"max_tokens\": max_tokens,\n    }\n    response = sagemaker_runtime.invoke_endpoint(\n        EndpointName=endpoint_name,\n        Body=json.dumps(payload),\n        ContentType=\"application/json\",\n    )\n    body = json.loads(response['Body'].read().decode('utf-8'))\n    message = body[\"choices\"][0][\"message\"]\n\n    reasoning = message.get(\"reasoning_content\", \"\")\n    answer = message.get(\"content\", \"\")\n    return reasoning, answer"
+   "source": "def chat_generation(user_prompt):\n    messages = [\n        {\n            \"role\": \"user\",\n            \"content\": user_prompt\n        }\n    ]\n    payload = {\n        \"messages\": messages,\n        \"temperature\": 0.3,\n        \"max_tokens\": max_tokens,\n    }\n    response = sagemaker_runtime.invoke_endpoint(\n        EndpointName=endpoint_name,\n        Body=json.dumps(payload),\n        ContentType=\"application/json\",\n    )\n    body = json.loads(response['Body'].read().decode('utf-8'))\n    message = body[\"choices\"][0][\"message\"]\n\n    # The reasoning field name may vary by vLLM version\n    reasoning = message.get(\"reasoning_content\") or message.get(\"reasoning\", \"\")\n    answer = message.get(\"content\", \"\")\n    return reasoning, answer"
   },
   {
    "cell_type": "code",
@@ -48,7 +48,17 @@
    "id": "inference",
    "metadata": {},
    "outputs": [],
-   "source": "user_prompt = \"What is cybersecurity?\"\n\nreasoning, answer = chat_generation(user_prompt)\n\nprint(\"=== Reasoning (chain-of-thought) ===\")\nprint(reasoning)\nprint()\nprint(\"=== Answer ===\")\nprint(answer)"
+   "source": [
+    "user_prompt = \"What is cybersecurity?\"\n",
+    "\n",
+    "reasoning, answer = chat_generation(user_prompt)\n",
+    "\n",
+    "print(\"=== Reasoning (chain-of-thought) ===\")\n",
+    "print(reasoning)\n",
+    "print()\n",
+    "print(\"=== Answer ===\")\n",
+    "print(answer)"
+   ]
   }
  ],
  "metadata": {
@@ -58,8 +68,16 @@
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.12.0"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,

--- a/3_adoptions/deployment/sagemaker/foundation_sec_8b_reasoning/inference.ipynb
+++ b/3_adoptions/deployment/sagemaker/foundation_sec_8b_reasoning/inference.ipynb
@@ -1,0 +1,98 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro-md",
+   "metadata": {},
+   "source": [
+    "# Inference\n",
+    "\n",
+    "This continues from [the deployment notebook](https://github.com/RobustIntelligence/foundation-ai-cookbook/blob/main/3_adoptions/deployment/sagemaker/foundation_sec_8b_reasoning/deploy.ipynb). <br>\n",
+    "Let's perform inference using the reasoning model deployed on Amazon SageMaker AI. <br>\n",
+    "As a prerequisite, please ensure you have access to SageMaker from the environment where this notebook is being run.\n",
+    "\n",
+    "Since this is a reasoning model, the response will contain a `reasoning_content` field with the chain-of-thought\n",
+    "and a `content` field with the final answer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "imports",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import boto3\n",
+    "import json"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "config",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sagemaker_runtime = boto3.client('sagemaker-runtime')\n",
+    "endpoint_name = ''  # copy & paste an endpoint created by the deployment notebook\n",
+    "\n",
+    "# Reasoning models produce more tokens due to chain-of-thought, so set a higher limit\n",
+    "max_tokens = 8192"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "chat-fn",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def chat_generation(user_prompt):\n",
+    "    messages = [\n",
+    "        {\n",
+    "            \"role\": \"user\",\n",
+    "            \"content\": user_prompt\n",
+    "        }\n",
+    "    ]\n",
+    "    payload = {\n",
+    "        \"messages\": messages,\n",
+    "        \"temperature\": 0.3,\n",
+    "        \"max_tokens\": max_tokens,\n",
+    "    }\n",
+    "    response = sagemaker_runtime.invoke_endpoint(\n",
+    "        EndpointName=endpoint_name,\n",
+    "        Body=json.dumps(payload),\n",
+    "        ContentType=\"application/json\",\n",
+    "        CustomAttributes='accept_eula=false'\n",
+    "    )\n",
+    "    body = json.loads(response['Body'].read().decode('utf-8'))\n",
+    "    message = body[\"choices\"][0][\"message\"]\n",
+    "\n",
+    "    reasoning = message.get(\"reasoning_content\", \"\")\n",
+    "    answer = message.get(\"content\", \"\")\n",
+    "    return reasoning, answer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "inference",
+   "metadata": {},
+   "outputs": [],
+   "source": "user_prompt = \"What is cybersecurity?\"\n\nreasoning, answer = chat_generation(user_prompt)\n\nprint(\"=== Reasoning (chain-of-thought) ===\")\nprint(reasoning)\nprint()\nprint(\"=== Answer ===\")\nprint(answer)"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Summary
- Add deployment and inference notebooks for deploying `fdtn-ai/Foundation-Sec-8B-Reasoning` to SageMaker using the AWS vLLM container image

Test plan
- Deploy the model to SageMaker using deploy.ipynb and verify the endpoint comes up
- Run inference.ipynb and verify reasoning_content and content are returned separately