### PR TITLE
Add Bedrock deployment cookbook for Foundation-Sec-8B-Reasoning

### DIFF
--- a/3_adoptions/deployment/bedrock/README.md
+++ b/3_adoptions/deployment/bedrock/README.md
@@ -13,7 +13,7 @@ Our reasoning model that produces chain-of-thought traces for security tasks.
 ## Getting Started
 
 1. Upload your model to S3 using the included [`upload_hf_to_s3.py`](./upload_hf_to_s3.py) helper script (or bring your own S3 artifacts)
-2. Start with the `deploy.ipynb` notebook to import the model into Bedrock
+2. Import the model into Bedrock using `deploy.ipynb`, or through the [AWS Console](https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-import-model.html)
 3. Use the `inference.ipynb` notebook to test your imported model
 
 ## Prerequisites

--- a/3_adoptions/deployment/bedrock/README.md
+++ b/3_adoptions/deployment/bedrock/README.md
@@ -1,0 +1,28 @@
+# Deployment and Inference with Amazon Bedrock
+
+This directory contains cookbooks for deploying and running inference with Foundation AI models on Amazon Bedrock using Custom Model Import. Model artifacts are imported from S3 and Bedrock creates a fully managed endpoint. No containers or instance types to configure.
+
+## Available Models
+
+### Foundation-Sec-8B-Reasoning (Reasoning Model)
+Our reasoning model that produces chain-of-thought traces for security tasks.
+- **Deploy**: [foundation_sec_8b_reasoning/deploy.ipynb](./foundation_sec_8b_reasoning/deploy.ipynb)
+- **Inference**: [foundation_sec_8b_reasoning/inference.ipynb](./foundation_sec_8b_reasoning/inference.ipynb)
+- **Documentation**: [foundation_sec_8b_reasoning/README.md](./foundation_sec_8b_reasoning/README.md)
+
+## Getting Started
+
+1. Ensure your model artifacts are on S3 (BF16 safetensors format)
+2. Start with the `deploy.ipynb` notebook to import the model into Bedrock
+3. Use the `inference.ipynb` notebook to test your imported model
+
+## Prerequisites
+
+- AWS account with Bedrock access in a supported region (`us-east-1`, `us-east-2`, `us-west-2`, or `eu-central-1`)
+- Model artifacts uploaded to S3
+- IAM user with S3, Bedrock, and PassRole permissions
+- A Bedrock service role with S3 read access
+
+## Note
+
+Bedrock imported models bill **continuously** (~$1,080-1,440/month for 8B). Delete them when not in use.

--- a/3_adoptions/deployment/bedrock/README.md
+++ b/3_adoptions/deployment/bedrock/README.md
@@ -12,7 +12,7 @@ Our reasoning model that produces chain-of-thought traces for security tasks.
 
 ## Getting Started
 
-1. Ensure your model artifacts are on S3 (BF16 safetensors format)
+1. Upload your model to S3 using the included [`upload_hf_to_s3.py`](./upload_hf_to_s3.py) helper script (or bring your own S3 artifacts)
 2. Start with the `deploy.ipynb` notebook to import the model into Bedrock
 3. Use the `inference.ipynb` notebook to test your imported model
 

--- a/3_adoptions/deployment/bedrock/foundation_sec_8b_reasoning/README.md
+++ b/3_adoptions/deployment/bedrock/foundation_sec_8b_reasoning/README.md
@@ -1,0 +1,25 @@
+# Foundation-Sec-8B-Reasoning Model - Bedrock Deployment
+
+This directory contains cookbooks for deploying and running inference with the **Foundation-Sec-8B-Reasoning** model on Amazon Bedrock via Custom Model Import.
+
+We provide two sample notebooks:
+1. Deploy Model: Import the model into Bedrock from S3 ([link](./deploy.ipynb)).
+2. Run Inference: Perform inference using the imported model ([link](./inference.ipynb)).
+
+Please note that we assume you already have AWS accounts or contracts and are aware that deployments will incur costs.
+
+## Important Notes
+
+- **API format:** Bedrock's `invoke_model` accepts OpenAI-style messages for imported models — no tokenizer or manual chat template needed.
+- **Reasoning parsing:** The model outputs `<think>...</think>` reasoning traces inline. The inference notebook includes a parser to split the reasoning from the final answer.
+- **Always-on billing:** Imported models bill continuously (~$1,080-1,440/month for 8B). Delete the imported model when not in use.
+
+## Troubleshooting
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| `ModelNotReadyException` | Cold start after import | Wait ~5 minutes and retry |
+| `AccessDeniedException` | Missing Bedrock or PassRole permissions | Check IAM policies |
+| Raw `<think>` tags in output | Model not triggering reasoning | Verify the model was imported after November 2025 |
+
+For additional questions, please refer to the main [Bedrock README](../README.md) or consult the [AWS Bedrock documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-import-model.html).

--- a/3_adoptions/deployment/bedrock/foundation_sec_8b_reasoning/deploy.ipynb
+++ b/3_adoptions/deployment/bedrock/foundation_sec_8b_reasoning/deploy.ipynb
@@ -72,7 +72,37 @@
    "id": "e194c6e5",
    "metadata": {},
    "outputs": [],
-   "source": "# Uncomment this cell to create the Bedrock service role.\n# Your IAM user needs iam:CreateRole and iam:AttachRolePolicy permissions.\n\n# iam = boto3.client(\"iam\")\n# role_name = \"bedrock-model-import-role\"\n#\n# trust_policy = json.dumps({\n#     \"Version\": \"2012-10-17\",\n#     \"Statement\": [{\n#         \"Effect\": \"Allow\",\n#         \"Principal\": {\"Service\": \"bedrock.amazonaws.com\"},\n#         \"Action\": \"sts:AssumeRole\",\n#     }]\n# })\n#\n# role = iam.create_role(\n#     RoleName=role_name,\n#     AssumeRolePolicyDocument=trust_policy,\n#     Description=\"Allows Bedrock to read model artifacts from S3\",\n# )\n#\n# iam.attach_role_policy(\n#     RoleName=role_name,\n#     PolicyArn=\"arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess\",\n# )\n#\n# role_arn = role[\"Role\"][\"Arn\"]\n# print(f\"Created role: {role_arn}\")\n# print(\"Paste this ARN into BEDROCK_ROLE_ARN below.\")"
+   "source": [
+    "# Uncomment this cell to create the Bedrock service role.\n",
+    "# Your IAM user needs iam:CreateRole and iam:AttachRolePolicy permissions.\n",
+    "\n",
+    "# iam = boto3.client(\"iam\")\n",
+    "# role_name = \"bedrock-model-import-role\"\n",
+    "#\n",
+    "# trust_policy = json.dumps({\n",
+    "#     \"Version\": \"2012-10-17\",\n",
+    "#     \"Statement\": [{\n",
+    "#         \"Effect\": \"Allow\",\n",
+    "#         \"Principal\": {\"Service\": \"bedrock.amazonaws.com\"},\n",
+    "#         \"Action\": \"sts:AssumeRole\",\n",
+    "#     }]\n",
+    "# })\n",
+    "#\n",
+    "# role = iam.create_role(\n",
+    "#     RoleName=role_name,\n",
+    "#     AssumeRolePolicyDocument=trust_policy,\n",
+    "#     Description=\"Allows Bedrock to read model artifacts from S3\",\n",
+    "# )\n",
+    "#\n",
+    "# iam.attach_role_policy(\n",
+    "#     RoleName=role_name,\n",
+    "#     PolicyArn=\"arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess\",\n",
+    "# )\n",
+    "#\n",
+    "# role_arn = role[\"Role\"][\"Arn\"]\n",
+    "# print(f\"Created role: {role_arn}\")\n",
+    "# print(\"Paste this ARN into BEDROCK_ROLE_ARN below.\")"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -88,13 +118,28 @@
    "id": "9672a563",
    "metadata": {},
    "outputs": [],
-   "source": "S3_BUCKET_URI = \"\"  # e.g. \"s3://your-bucket/foundation-sec-8b-reasoning/\"\nassert S3_BUCKET_URI, \"Set S3_BUCKET_URI above before running\"\n\nBEDROCK_ROLE_ARN = \"\"  # e.g. \"arn:aws:iam::123456789012:role/bedrock-model-import-role\"\nassert BEDROCK_ROLE_ARN, \"Set BEDROCK_ROLE_ARN above before running\"\n\nAWS_REGION = \"us-west-2\"\nIMPORTED_MODEL_NAME = \"foundation-sec-8b-reasoning\""
+   "source": [
+    "S3_BUCKET_URI = \"\"  # e.g. \"s3://your-bucket/foundation-sec-8b-reasoning/\"\n",
+    "assert S3_BUCKET_URI, \"Set S3_BUCKET_URI above before running\"\n",
+    "\n",
+    "BEDROCK_ROLE_ARN = \"\"  # e.g. \"arn:aws:iam::123456789012:role/bedrock-model-import-role\"\n",
+    "assert BEDROCK_ROLE_ARN, \"Set BEDROCK_ROLE_ARN above before running\"\n",
+    "\n",
+    "AWS_REGION = \"us-west-2\"\n",
+    "IMPORTED_MODEL_NAME = \"foundation-sec-8b-reasoning\""
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "022f4050",
    "metadata": {},
-   "source": "## Import Model\n\nSubmit the import job and wait for completion. This typically takes **5–15 minutes**.\n\nYou can also import models through the AWS Console: **Bedrock → Imported models → Import model**. See the [AWS docs](https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-import-model.html) for a walkthrough."
+   "source": [
+    "## Import Model\n",
+    "\n",
+    "Submit the import job and wait for completion. This typically takes **5–15 minutes**.\n",
+    "\n",
+    "You can also import models through the AWS Console: **Bedrock → Imported models → Import model**. See the [AWS docs](https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-import-model.html) for a walkthrough."
+   ]
   },
   {
    "cell_type": "code",
@@ -168,20 +213,42 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7abf352c",
-   "metadata": {},
-   "outputs": [],
-   "source": "# Uncomment to delete the imported model and stop ongoing costs.\n# Bedrock imported models bill continuously (~$1,080-1,440/month for 8B).\n# S3 files remain intact (~$0.35/month) and you can re-import anytime.\n#\n# bedrock_client.delete_imported_model(modelIdentifier=model_arn)"
+   "cell_type": "markdown",
+   "id": "f63c4b96",
+   "source": "## Cleanup",
+   "metadata": {}
   },
   {
    "cell_type": "code",
-   "id": "06798d0a",
-   "source": "# Uncomment to delete the Bedrock service role created in the Prerequisites section.\n#\n# iam = boto3.client(\"iam\")\n# iam.detach_role_policy(\n#     RoleName=\"bedrock-model-import-role\",\n#     PolicyArn=\"arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess\",\n# )\n# iam.delete_role(RoleName=\"bedrock-model-import-role\")\n# print(\"Deleted role: bedrock-model-import-role\")",
+   "execution_count": 10,
+   "id": "7abf352c",
    "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment to delete the imported model and stop ongoing costs.\n",
+    "# Bedrock imported models bill continuously (~$1,080-1,440/month for 8B).\n",
+    "# S3 files remain intact (~$0.35/month) and you can re-import anytime.\n",
+    "#\n",
+    "# bedrock_client.delete_imported_model(modelIdentifier=model_arn)"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
-   "outputs": []
+   "id": "06798d0a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment to delete the Bedrock service role created in the Prerequisites section.\n",
+    "#\n",
+    "# iam = boto3.client(\"iam\")\n",
+    "# iam.detach_role_policy(\n",
+    "#     RoleName=\"bedrock-model-import-role\",\n",
+    "#     PolicyArn=\"arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess\",\n",
+    "# )\n",
+    "# iam.delete_role(RoleName=\"bedrock-model-import-role\")\n",
+    "# print(\"Deleted role: bedrock-model-import-role\")"
+   ]
   }
  ],
  "metadata": {

--- a/3_adoptions/deployment/bedrock/foundation_sec_8b_reasoning/deploy.ipynb
+++ b/3_adoptions/deployment/bedrock/foundation_sec_8b_reasoning/deploy.ipynb
@@ -94,11 +94,7 @@
    "cell_type": "markdown",
    "id": "022f4050",
    "metadata": {},
-   "source": [
-    "## Import Model\n",
-    "\n",
-    "Submit the import job and wait for completion. This typically takes **5–15 minutes**."
-   ]
+   "source": "## Import Model\n\nSubmit the import job and wait for completion. This typically takes **5–15 minutes**.\n\nYou can also import models through the AWS Console: **Bedrock → Imported models → Import model**. See the [AWS docs](https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-import-model.html) for a walkthrough."
   },
   {
    "cell_type": "code",
@@ -177,7 +173,15 @@
    "id": "7abf352c",
    "metadata": {},
    "outputs": [],
-   "source": "# Uncomment to delete the imported model and stop ongoing costs.\n# Bedrock imported models bill continuously (~$1,080-1,440/month for 8B).\n# S3 files remain intact (~$0.35/month) and you can re-import anytime.\n#\n# bedrock_client.delete_imported_model(modelIdentifier=model_arn)\n\n# Uncomment to also delete the Bedrock service role created in the Prerequisites section.\n#\n# iam = boto3.client(\"iam\")\n# iam.detach_role_policy(\n#     RoleName=\"bedrock-model-import-role\",\n#     PolicyArn=\"arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess\",\n# )\n# iam.delete_role(RoleName=\"bedrock-model-import-role\")\n# print(\"Deleted role: bedrock-model-import-role\")"
+   "source": "# Uncomment to delete the imported model and stop ongoing costs.\n# Bedrock imported models bill continuously (~$1,080-1,440/month for 8B).\n# S3 files remain intact (~$0.35/month) and you can re-import anytime.\n#\n# bedrock_client.delete_imported_model(modelIdentifier=model_arn)"
+  },
+  {
+   "cell_type": "code",
+   "id": "06798d0a",
+   "source": "# Uncomment to delete the Bedrock service role created in the Prerequisites section.\n#\n# iam = boto3.client(\"iam\")\n# iam.detach_role_policy(\n#     RoleName=\"bedrock-model-import-role\",\n#     PolicyArn=\"arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess\",\n# )\n# iam.delete_role(RoleName=\"bedrock-model-import-role\")\n# print(\"Deleted role: bedrock-model-import-role\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   }
  ],
  "metadata": {

--- a/3_adoptions/deployment/bedrock/foundation_sec_8b_reasoning/deploy.ipynb
+++ b/3_adoptions/deployment/bedrock/foundation_sec_8b_reasoning/deploy.ipynb
@@ -1,0 +1,204 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "32f970ba",
+   "metadata": {},
+   "source": [
+    "# Deployment\n",
+    "\n",
+    "Let's deploy the Foundation AI Foundation-Sec-8B-Reasoning model to **Amazon Bedrock** using Custom Model Import. <br>\n",
+    "You can use the model deployed by this notebook for inference. Refer to [the inference notebook](https://github.com/cisco-foundation-ai/cookbook/blob/main/3_adoptions/deployment/bedrock/foundation_sec_8b_reasoning/inference.ipynb) for sample code.\n",
+    "\n",
+    "Bedrock imports model artifacts from S3 and creates a fully managed endpoint - no containers or instance types to configure.\n",
+    "\n",
+    "As a prerequisite, you need:\n",
+    "- Model artifacts on S3 (BF16 safetensors format)\n",
+    "- IAM user with S3, Bedrock, and PassRole permissions\n",
+    "- A Bedrock service role with S3 read access"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32cbc50f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -r ../requirements.txt --quiet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c3f8427",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "import json\n",
+    "import boto3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3b7e1de9",
+   "metadata": {},
+   "source": [
+    "## Prerequisites (optional)\n",
+    "\n",
+    "If your model is already on S3 and you already have a Bedrock service role, skip to **Configuration** below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f21d8193",
+   "metadata": {},
+   "source": [
+    "**Upload model to S3.** Bedrock imports from S3, not HuggingFace. Use the helper script to stream files directly (no local disk needed):\n",
+    "\n",
+    "```bash\n",
+    "python ../upload_hf_to_s3.py --s3-uri s3://your-bucket/foundation-sec-8b-reasoning/\n",
+    "```\n",
+    "\n",
+    "For gated models, set `HF_TOKEN` first. To upload a different model, pass `--repo-id`.\n",
+    "\n",
+    "**Create Bedrock service role.** Bedrock needs an IAM role to read your S3 files. Uncomment and run the cell below to create one, or skip if you already have a role."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e194c6e5",
+   "metadata": {},
+   "outputs": [],
+   "source": "# Uncomment this cell to create the Bedrock service role.\n# Your IAM user needs iam:CreateRole and iam:AttachRolePolicy permissions.\n\n# iam = boto3.client(\"iam\")\n# role_name = \"bedrock-model-import-role\"\n#\n# trust_policy = json.dumps({\n#     \"Version\": \"2012-10-17\",\n#     \"Statement\": [{\n#         \"Effect\": \"Allow\",\n#         \"Principal\": {\"Service\": \"bedrock.amazonaws.com\"},\n#         \"Action\": \"sts:AssumeRole\",\n#     }]\n# })\n#\n# role = iam.create_role(\n#     RoleName=role_name,\n#     AssumeRolePolicyDocument=trust_policy,\n#     Description=\"Allows Bedrock to read model artifacts from S3\",\n# )\n#\n# iam.attach_role_policy(\n#     RoleName=role_name,\n#     PolicyArn=\"arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess\",\n# )\n#\n# role_arn = role[\"Role\"][\"Arn\"]\n# print(f\"Created role: {role_arn}\")\n# print(\"Paste this ARN into BEDROCK_ROLE_ARN below.\")"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6d654da",
+   "metadata": {},
+   "source": [
+    "## Configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9672a563",
+   "metadata": {},
+   "outputs": [],
+   "source": "S3_BUCKET_URI = \"\"  # e.g. \"s3://your-bucket/foundation-sec-8b-reasoning/\"\nassert S3_BUCKET_URI, \"Set S3_BUCKET_URI above before running\"\n\nBEDROCK_ROLE_ARN = \"\"  # e.g. \"arn:aws:iam::123456789012:role/bedrock-model-import-role\"\nassert BEDROCK_ROLE_ARN, \"Set BEDROCK_ROLE_ARN above before running\"\n\nAWS_REGION = \"us-west-2\"\nIMPORTED_MODEL_NAME = \"foundation-sec-8b-reasoning\""
+  },
+  {
+   "cell_type": "markdown",
+   "id": "022f4050",
+   "metadata": {},
+   "source": [
+    "## Import Model\n",
+    "\n",
+    "Submit the import job and wait for completion. This typically takes **5–15 minutes**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ec9b23a4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bedrock_client = boto3.client(\"bedrock\", region_name=AWS_REGION)\n",
+    "\n",
+    "job_name = f\"import-{IMPORTED_MODEL_NAME}-{int(time.time())}\"\n",
+    "\n",
+    "print(f\"Model name : {IMPORTED_MODEL_NAME}\")\n",
+    "print(f\"S3 source  : {S3_BUCKET_URI}\")\n",
+    "print(f\"Region     : {AWS_REGION}\")\n",
+    "print(f\"Job name   : {job_name}\")\n",
+    "print()\n",
+    "\n",
+    "response = bedrock_client.create_model_import_job(\n",
+    "    jobName=job_name,\n",
+    "    importedModelName=IMPORTED_MODEL_NAME,\n",
+    "    roleArn=BEDROCK_ROLE_ARN,\n",
+    "    modelDataSource={\n",
+    "        \"s3DataSource\": {\n",
+    "            \"s3Uri\": S3_BUCKET_URI\n",
+    "        }\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "job_arn = response[\"jobArn\"]\n",
+    "print(f\"Import job submitted: {job_arn}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e4ad9c60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Waiting for import to complete (typically 5-15 minutes)...\\n\")\n",
+    "\n",
+    "while True:\n",
+    "    job_status = bedrock_client.get_model_import_job(jobIdentifier=job_arn)\n",
+    "    status = job_status[\"status\"]\n",
+    "\n",
+    "    if status == \"Completed\":\n",
+    "        model_arn = job_status[\"importedModelArn\"]\n",
+    "        print(f\"\\nImport complete!\")\n",
+    "        print(f\"Model ARN: {model_arn}\")\n",
+    "        print(f\"\\nShare this ARN with your team to use the model.\")\n",
+    "        break\n",
+    "    elif status == \"Failed\":\n",
+    "        print(f\"\\nImport failed!\")\n",
+    "        print(json.dumps(job_status, indent=2, default=str))\n",
+    "        raise RuntimeError(\"Bedrock import job failed\")\n",
+    "    else:\n",
+    "        elapsed = int(time.time() - int(job_name.split(\"-\")[-1]))\n",
+    "        print(f\"  Status: {status} (elapsed: {elapsed // 60}m {elapsed % 60}s)\", end=\"\\r\")\n",
+    "        time.sleep(15)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ab6f3a73",
+   "metadata": {},
+   "source": [
+    "## Next Steps\n",
+    "\n",
+    "The Model ARN is what you'll use for [inference](https://github.com/cisco-foundation-ai/cookbook/blob/main/3_adoptions/deployment/bedrock/foundation_sec_8b_reasoning/inference.ipynb). You can also view imported models in the AWS Console under **Bedrock → Imported models**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7abf352c",
+   "metadata": {},
+   "outputs": [],
+   "source": "# Uncomment to delete the imported model and stop ongoing costs.\n# Bedrock imported models bill continuously (~$1,080-1,440/month for 8B).\n# S3 files remain intact (~$0.35/month) and you can re-import anytime.\n#\n# bedrock_client.delete_imported_model(modelIdentifier=model_arn)\n\n# Uncomment to also delete the Bedrock service role created in the Prerequisites section.\n#\n# iam = boto3.client(\"iam\")\n# iam.detach_role_policy(\n#     RoleName=\"bedrock-model-import-role\",\n#     PolicyArn=\"arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess\",\n# )\n# iam.delete_role(RoleName=\"bedrock-model-import-role\")\n# print(\"Deleted role: bedrock-model-import-role\")"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/3_adoptions/deployment/bedrock/foundation_sec_8b_reasoning/inference.ipynb
+++ b/3_adoptions/deployment/bedrock/foundation_sec_8b_reasoning/inference.ipynb
@@ -1,0 +1,93 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e7df4de9",
+   "metadata": {},
+   "source": "# Inference\n\nThis continues from [the deployment notebook](https://github.com/cisco-foundation-ai/cookbook/blob/main/3_adoptions/deployment/bedrock/foundation_sec_8b_reasoning/deploy.ipynb). <br>\nLet's perform inference using the reasoning model deployed on Amazon Bedrock.\n\nBedrock's `invoke_model` API accepts OpenAI-style messages for imported models, so no tokenizer or chat template formatting is needed. Since this is a reasoning model, the response contains a `<think>...</think>` reasoning trace followed by the final answer."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6664b247",
+   "metadata": {},
+   "outputs": [],
+   "source": "%pip install boto3 --quiet"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "86675e7a",
+   "metadata": {},
+   "outputs": [],
+   "source": "import boto3\nimport json\nimport re"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c36fe60a",
+   "metadata": {},
+   "outputs": [],
+   "source": "AWS_REGION = \"us-west-2\"\nMODEL_ARN = \"\"  # copy from deploy notebook or: aws bedrock list-imported-models\nassert MODEL_ARN, \"Set MODEL_ARN above before running inference\"\n\nbedrock_runtime = boto3.client(\"bedrock-runtime\", region_name=AWS_REGION)\nmax_tokens = 8192"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5d8034e2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def parse_reasoning(raw_output: str) -> dict:\n",
+    "    \"\"\"Split model output at </think> into reasoning trace and final answer.\"\"\"\n",
+    "    match = re.search(r\"</think>\", raw_output, re.IGNORECASE)\n",
+    "    if match:\n",
+    "        reasoning = raw_output[:match.start()]\n",
+    "        content = raw_output[match.end():]\n",
+    "        reasoning = re.sub(r\"^\\s*<think>\\s*\", \"\", reasoning, flags=re.IGNORECASE)\n",
+    "        return {\n",
+    "            \"reasoning_content\": reasoning.strip(),\n",
+    "            \"content\": content.strip(),\n",
+    "        }\n",
+    "    return {\n",
+    "        \"reasoning_content\": None,\n",
+    "        \"content\": raw_output.strip(),\n",
+    "    }"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cf038a5c",
+   "metadata": {},
+   "outputs": [],
+   "source": "def chat_generation(user_prompt):\n    body = {\n        \"messages\": [\n            {\"role\": \"user\", \"content\": user_prompt}\n        ],\n        \"max_tokens\": max_tokens,\n        \"temperature\": 0.6,\n        \"top_p\": 0.95,\n    }\n\n    response = bedrock_runtime.invoke_model(\n        modelId=MODEL_ARN,\n        body=json.dumps(body),\n    )\n    response_body = json.loads(response[\"body\"].read())\n\n    raw_generation = response_body[\"choices\"][0][\"message\"][\"content\"]\n    parsed = parse_reasoning(raw_generation)\n\n    return parsed[\"reasoning_content\"], parsed[\"content\"]"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5f60f2e3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "user_prompt = \"What is cybersecurity?\"\n",
+    "\n",
+    "reasoning, answer = chat_generation(user_prompt)\n",
+    "\n",
+    "print(\"=== Reasoning (chain-of-thought) ===\")\n",
+    "print(reasoning)\n",
+    "print()\n",
+    "print(\"=== Answer ===\")\n",
+    "print(answer)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/3_adoptions/deployment/bedrock/requirements.txt
+++ b/3_adoptions/deployment/bedrock/requirements.txt
@@ -1,0 +1,3 @@
+boto3
+huggingface_hub
+tqdm

--- a/3_adoptions/deployment/bedrock/upload_hf_to_s3.py
+++ b/3_adoptions/deployment/bedrock/upload_hf_to_s3.py
@@ -1,0 +1,79 @@
+"""
+Stream model files from HuggingFace directly to S3 (no local disk needed).
+
+Usage:
+    python upload_hf_to_s3.py --repo-id fdtn-ai/Foundation-Sec-8B-Reasoning \
+                              --s3-uri s3://your-bucket/foundation-sec-8b-reasoning/
+
+Requires: pip install huggingface_hub boto3
+For gated models, set the HF_TOKEN environment variable.
+"""
+
+import argparse
+import os
+
+import boto3
+from huggingface_hub import HfFileSystem
+from tqdm import tqdm
+
+
+def parse_s3_uri(s3_uri):
+    if not s3_uri.startswith("s3://"):
+        raise ValueError(f"Invalid S3 URI: {s3_uri}")
+    path = s3_uri[5:]
+    parts = path.split("/", 1)
+    bucket = parts[0]
+    prefix = parts[1] if len(parts) > 1 else ""
+    return bucket, prefix
+
+
+def sync_hf_to_s3(repo_id, s3_uri):
+    fs = HfFileSystem()
+    s3_client = boto3.client("s3")
+
+    bucket, s3_prefix = parse_s3_uri(s3_uri)
+    if s3_prefix and not s3_prefix.endswith("/"):
+        s3_prefix += "/"
+
+    print(f"Scanning HuggingFace repo: {repo_id}")
+    files = fs.ls(repo_id, detail=False)
+    hf_files = [f for f in files if fs.isfile(f)]
+    print(f"Found {len(hf_files)} files. Starting transfer to S3...\n")
+
+    for hf_file in hf_files:
+        filename = hf_file.replace(f"{repo_id}/", "")
+        if filename.endswith(".bin"):
+            print(f"  Skipping {filename} (prefer safetensors)")
+            continue
+
+        s3_key = f"{s3_prefix}{filename}"
+        file_size = fs.info(hf_file).get("size", 0)
+
+        with fs.open(hf_file, "rb") as remote_file:
+            with tqdm(
+                total=file_size,
+                unit="B",
+                unit_scale=True,
+                desc=filename,
+            ) as pbar:
+                s3_client.upload_fileobj(
+                    remote_file, bucket, s3_key, Callback=pbar.update
+                )
+
+    print("\nUpload complete!")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Stream HuggingFace model to S3")
+    parser.add_argument(
+        "--repo-id",
+        default="fdtn-ai/Foundation-Sec-8B-Reasoning",
+        help="HuggingFace model ID (default: fdtn-ai/Foundation-Sec-8B-Reasoning)",
+    )
+    parser.add_argument(
+        "--s3-uri",
+        required=True,
+        help="S3 destination URI (e.g. s3://your-bucket/foundation-sec-8b-reasoning/)",
+    )
+    args = parser.parse_args()
+    sync_hf_to_s3(args.repo_id, args.s3_uri)


### PR DESCRIPTION
## Summary
- Deploy and inference notebooks for importing Foundation-Sec-8B-Reasoning into Amazon Bedrock via Custom Model Import
- Helper script (`upload_hf_to_s3.py`) to stream model artifacts from HuggingFace to S3 with tqdm progress
- Uses Bedrock's OpenAI-compatible `invoke_model` API. No tokenizer or chat template setup needed

## Testing
- Deployed the model using a custom model import job
- Invoked the model using the inference notebook
- Able to view reasoning content and the answer.